### PR TITLE
Update wrapper fcl for TFileMetadataMicroBooNE service to merge multiple plain root files.

### DIFF
--- a/python/experiment_utilities.py
+++ b/python/experiment_utilities.py
@@ -136,7 +136,7 @@ def get_sam_metadata(project, stage):
     result = result + '}\n'
     result = result + 'services.TFileMetadataMicroBooNE: @local::microboone_tfile_metadata\n'
     if hasattr(stage,'anamerge') and stage.anamerge == '1':
-        result = result + 'services.TFileMetadataMicroBooNE.Merge: true\n'
+        result = result + 'services.TFileMetadataMicroBooNE.Merge:  @local::microboone_tfile_metadata.GenerateTFileMetadata\n'
 
     return result
 


### PR DESCRIPTION
Update fcl wrapper generated by experiment_utilities.py to override the Merge fcl parameter such that all defined plain root files will be merged if <anamerge> is set.