### PR TITLE
Run123 detvar scripts

### DIFF
--- a/scripts/pick_combinedrecotree_wiremod_overlay_numi_sce.sh
+++ b/scripts/pick_combinedrecotree_wiremod_overlay_numi_sce.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+#------------------------------------------------------------------
+#
+# Purpose: This script is intended to update the configuration
+#          of the fhicl according to run number.
+#
+# Created: Liang Liu (liangliu@fnal.gov), 25-Nov-2024 
+#
+#------------------------------------------------------------------
+
+
+
+# Make sure batch environment variables needed by this script are defined.
+
+echo $FCL
+
+if [ x$FCL = x ]; then
+  echo "Variable FCL not defined."
+  exit 1
+fi
+
+# Make sure fcl file $FCL exists.
+
+if [ ! -f $FCL ]; then
+  echo "Fcl file $FCL does not exist."
+  exit 1
+fi
+
+# get the file that will be used as input for next stage
+next_stage_input=`ls -t1 *.root | egrep -v 'celltree|hist|larlite|larcv|Supplemental|TGraphs' | artroot_filter.py | head -n1`
+echo $next_stage_input
+run_number=`lar -c eventdump.fcl $next_stage_input -n 1 | grep "Begin processing the 1st record" | awk '{match($0, /run: ([0-9]+)/, arr); print arr[1]}'`
+echo $run_number
+# Make sure we got an int
+if [[ "$run_number" =~ ^-?[0-9]+$ ]]; then
+  # Make sure the run number is sensible
+  if [ "$run_number" -le "3419" ]; then
+    echo "run number too small, rechecking"
+    run_number=`echo $next_stage_input | cut -d '-' -f3`
+  elif [ "$run_number" -ge "0025769" ]; then
+    echo "run number too big, rechecking"
+    run_number=`echo $next_stage_input | cut -d '-' -f3`
+  fi
+else
+  echo "run number is not an integer, rechecking"
+  run_number=`echo $next_stage_input | cut -d '-' -f3`
+fi
+echo $run_number
+
+TEMPLATE_FHILE="run_combinedrecotree_run1_wiremod_overlay_numi_sce"
+PICKED_FHICL="run_combinedrecotree_run1_wiremod_overlay_numi_sce"
+if [ "$run_number" -ge "0003420"  ] && [  "0011048" -ge "$run_number"  ];    # in the run1 and run 2a run number interval; before full CRT
+then
+        echo "run run1 fhicl"
+        cat $FCL
+        mv $FCL backup_${FCL}.fcl
+        cat backup_${FCL}.fcl  | sed "s/run_combinedrecotree_run1_wiremod_overlay_numi_sce/run_combinedrecotree_run1_wiremod_overlay_numi_sce/g" > $FCL
+        cat $FCL
+        cat wrapper.fcl
+        mv wrapper.fcl backup_wrapper.fcl
+        cat backup_wrapper.fcl | sed "s/run_combinedrecotree_run1_wiremod_overlay_numi_sce/run_combinedrecotree_run1_wiremod_overlay_numi_sce/g" > wrapper.fcl
+        cat wrapper.fcl
+        PICKED_FHICL="run_combinedrecotree_run1_wiremod_overlay_numi_sce"
+elif [ "$run_number" -ge "0011049"  ] && [  "18960" -ge "$run_number"  ];   # run 2b after full CRT up through the end of run3
+then
+        echo "run run3 fhicl"
+        cat $FCL
+        mv $FCL backup_${FCL}.fcl
+        cat backup_${FCL}.fcl  | sed "s/run_combinedrecotree_run1_wiremod_overlay_numi_sce/run_combinedrecotree_run3_wiremod_overlay_numi_sce/g" > $FCL
+        cat $FCL
+        cat wrapper.fcl
+        mv wrapper.fcl backup_wrapper.fcl
+        cat backup_wrapper.fcl | sed "s/run_combinedrecotree_run1_wiremod_overlay_numi_sce/run_combinedrecotree_run3_wiremod_overlay_numi_sce/g" > wrapper.fcl
+        cat wrapper.fcl
+        PICKED_FHICL="run_combinedrecotree_run3_wiremod_overlay_numi_sce"
+elif [ "$run_number" -ge "18961"  ] && [  "0025769" -ge "$run_number"  ];   # run 4 and beyond, not a typo, no run4 fhicl
+then
+        echo "run run4 fhicl"
+        cat $FCL
+        mv $FCL backup_${FCL}.fcl
+        cat backup_${FCL}.fcl  | sed "s/run_combinedrecotree_run1_wiremod_overlay_numi_sce/run_combinedrecotree_run4_wiremod_overlay_numi/g" > $FCL
+        cat $FCL
+        cat wrapper.fcl
+        mv wrapper.fcl backup_wrapper.fcl
+        cat backup_wrapper.fcl | sed "s/run_combinedrecotree_run1_wiremod_overlay_numi_sce/run_combinedrecotree_run4_wiremod_overlay_numi/g" > wrapper.fcl
+        cat wrapper.fcl
+        PICKED_FHICL="run_combinedrecotree_run4_wiremod_overlay_numi"
+fi
+
+for fhicl_stage in Stage*fcl;
+do
+        mv $fhicl_stage backup_${fhicl_stage}.fcl
+        cat backup_${fhicl_stage}.fcl  | sed "s/${TEMPLATE_FHILE}/${PICKED_FHICL}/g" > $fhicl_stage
+done

--- a/scripts/pick_combinedrecotree_wiremod_overlay_sce.sh
+++ b/scripts/pick_combinedrecotree_wiremod_overlay_sce.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+#------------------------------------------------------------------
+#
+# Purpose: This script is intended to update the configuration
+#          of the fhicl according to run number.
+#
+# Created: Liang Liu (liangliu@fnal.gov), 25-Nov-2024 
+#
+#------------------------------------------------------------------
+
+
+
+# Make sure batch environment variables needed by this script are defined.
+
+echo $FCL
+
+if [ x$FCL = x ]; then
+  echo "Variable FCL not defined."
+  exit 1
+fi
+
+# Make sure fcl file $FCL exists.
+
+if [ ! -f $FCL ]; then
+  echo "Fcl file $FCL does not exist."
+  exit 1
+fi
+
+# get the file that will be used as input for next stage
+next_stage_input=`ls -t1 *.root | egrep -v 'celltree|hist|larlite|larcv|Supplemental|TGraphs' | artroot_filter.py | head -n1`
+echo $next_stage_input
+run_number=`lar -c eventdump.fcl $next_stage_input -n 1 | grep "Begin processing the 1st record" | awk '{match($0, /run: ([0-9]+)/, arr); print arr[1]}'`
+echo $run_number
+# Make sure we got an int
+if [[ "$run_number" =~ ^-?[0-9]+$ ]]; then
+  # Make sure the run number is sensible
+  if [ "$run_number" -le "3419" ]; then
+    echo "run number too small, rechecking"
+    run_number=`echo $next_stage_input | cut -d '-' -f3`
+  elif [ "$run_number" -ge "0025769" ]; then
+    echo "run number too big, rechecking"
+    run_number=`echo $next_stage_input | cut -d '-' -f3`
+  fi
+else
+  echo "run number is not an integer, rechecking"
+  run_number=`echo $next_stage_input | cut -d '-' -f3`
+fi
+echo $run_number
+
+TEMPLATE_FHILE="run_combinedrecotree_wiremod_overlay_sce"
+PICKED_FHICL="run_combinedrecotree_wiremod_overlay_sce"
+if [ "$run_number" -ge "0003420"  ] && [  "0011048" -ge "$run_number"  ];    # run1 and run 2a run number interval; before full CRT
+then
+        echo "run run1 fhicl"
+        cat $FCL
+        mv $FCL backup_${FCL}.fcl
+        cat backup_${FCL}.fcl  | sed "s/run_combinedrecotree_wiremod_overlay_sce/run_combinedrecotree_wiremod_overlay_sce/g" > $FvCL
+        cat $FCL
+        cat wrapper.fcl
+        mv wrapper.fcl backup_wrapper.fcl
+        cat backup_wrapper.fcl | sed "s/run_combinedrecotree_wiremod_overlay_sce/run_combinedrecotree_wiremod_overlay_sce/g" > wrapper.fcl
+        cat wrapper.fcl
+        PICKED_FHICL="run_combinedrecotree_wiremod_overlay_sce"
+elif [ "$run_number" -ge "0011049"  ] && [  "13696" -ge "$run_number"  ];   # run 2b after full CRT
+then
+        echo "run run2b fhicl"
+        cat $FCL
+        mv $FCL backup_${FCL}.fcl
+        cat backup_${FCL}.fcl  | sed "s/run_combinedrecotree_wiremod_overlay_sce/run_combinedrecotree_run3_normLArPIDWeights_wiremod_overlay_sce/g" > $FCL
+        cat $FCL
+        cat wrapper.fcl
+        mv wrapper.fcl backup_wrapper.fcl
+        cat backup_wrapper.fcl | sed "s/run_combinedrecotree_wiremod_overlay_sce/run_combinedrecotree_run3_normLArPIDWeights_wiremod_overlay_sce/g" > wrapper.fcl
+        cat wrapper.fcl
+        PICKED_FHICL="run_combinedrecotree_run3_normLArPIDWeights_wiremod_overlay_sce"
+elif [ "$run_number" -ge "13697"  ] && [  "18960" -ge "$run_number"  ];   # run 3
+then
+        echo "run run3 fhicl"
+        cat $FCL
+        mv $FCL backup_${FCL}.fcl
+        cat backup_${FCL}.fcl  | sed "s/run_combinedrecotree_wiremod_overlay_sce/run_combinedrecotree_run3_wiremod_overlay_sce/g" > $FCL
+        cat $FCL
+        cat wrapper.fcl
+        mv wrapper.fcl backup_wrapper.fcl
+        cat backup_wrapper.fcl | sed "s/run_combinedrecotree_wiremod_overlay_sce/run_combinedrecotree_run3_wiremod_overlay_sce/g" > wrapper.fcl
+        cat wrapper.fcl
+        PICKED_FHICL="run_combinedrecotree_run3_wiremod_overlay_sce"
+elif [ "$run_number" -ge "18961"  ] && [  "0025769" -ge "$run_number"  ];   # run 4 and beyond, not a typo, no sce fhicl
+then
+        echo "run run4 fhicl"
+        cat $FCL
+        mv $FCL backup_${FCL}.fcl
+        cat backup_${FCL}.fcl  | sed "s/run_combinedrecotree_wiremod_overlay_sce/run_combinedrecotree_run4_wiremod_overlay/g" > $FCL
+        cat $FCL
+        cat wrapper.fcl
+        mv wrapper.fcl backup_wrapper.fcl
+        cat backup_wrapper.fcl | sed "s/run_combinedrecotree_wiremod_overlay_sce/run_combinedrecotree_run4_wiremod_overlay/g" > wrapper.fcl
+        cat wrapper.fcl
+        PICKED_FHICL="run_combinedrecotree_run4_wiremod_overlay"
+fi
+
+for fhicl_stage in Stage*fcl;
+do
+        mv $fhicl_stage backup_${fhicl_stage}.fcl
+        cat backup_${fhicl_stage}.fcl  | sed "s/${TEMPLATE_FHILE}/${PICKED_FHICL}/g" > $fhicl_stage
+done

--- a/scripts/set_wc_detvar_filetype.sh
+++ b/scripts/set_wc_detvar_filetype.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+#------------------------------------------------------------------
+#
+# Purpose: This script runs merge_dlreco_fnal_data_lantern.sh. 
+#          but only if the grid was unable to fetch the dlreco file.
+#
+# Created: Ben Bogart (benbogart777@gmail.com@fnal.gov), 23-May-2026 
+#
+#------------------------------------------------------------------
+
+# Read the config
+
+deffiletype=''
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+
+  -t|--filetype )
+    if [ $# -gt 1 ]; then
+      echo "Defining WireCell DetVar filetype to be $2"
+      deffiletype=$2
+      shift
+    else
+      echo "Bad $1 argument"
+      exit 1
+    fi
+    ;;
+
+  -* )
+    echo "Unknown option $1"
+    dohelp
+    exit 1
+    ;;
+
+  * )
+    echo "Bad argument $1"
+    dohelp
+    exit 1
+    ;;
+
+  esac
+  shift
+done
+
+# Check options.
+
+if [ x$reco1def = x ]; then
+  echo "No WireCell DetVar filetype specified."
+  exit 1
+fi
+
+echo $reco1def > $reco1def.fcl
+
+exit 0

--- a/scripts/set_wc_detvar_filetype.sh
+++ b/scripts/set_wc_detvar_filetype.sh
@@ -44,11 +44,11 @@ done
 
 # Check options.
 
-if [ x$reco1def = x ]; then
+if [ x$deffiletype = x ]; then
   echo "No WireCell DetVar filetype specified."
   exit 1
 fi
 
-echo $reco1def > $reco1def.fcl
+echo $deffiletype > $deffiletype.fcl
 
 exit 0


### PR DESCRIPTION
Three new scripts to be used for the production of runs1-3 DetVar samples. The set_wc_detvar_filetype.sh ensures the DetVar type is set correctly for the Wire-Cell ntuple maker. The pick_combinedrecotree_wiremod_overlay_sce.sh and pick_combinedrecotree_wiremod_overlay_numi_sce.sh are for swapping between wiremode ntuple maker fhicls for different run periods when the sample needs special SCE treatment.